### PR TITLE
#23 bucket should no longer use random provider

### DIFF
--- a/journal/week1.md
+++ b/journal/week1.md
@@ -51,4 +51,23 @@ This is the default file to load in terraform variables in blunk
 - TODO: document which terraform variables takes presendence.
 
 
+## Dealing With Configuration Drift
 
+## What happens if we lose our state file?
+
+If you lose your statefile, you most likley have to tear down all your cloud infrastructure manually.
+
+You can use terraform port but it won't for all cloud resources. You need check the terraform providers documentation for which resources support import.
+
+### Fix Missing Resources with Terraform Import
+
+`terraform import aws_s3_bucket.bucket bucket-name`
+
+[Terraform Import](https://developer.hashicorp.com/terraform/cli/import)
+[AWS S3 Bucket Import](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#import)
+
+### Fix Manual Configuration
+
+If someone goes and delete or modifies cloud resource manually through ClickOps. 
+
+If we run Terraform plan is with attempt to put our infrstraucture back into the expected state fixing Configuration Drift

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,3 @@
-output "random_bucket_name" {
-  value = random_string.bucket_name.result
+output "bucket_name" {
+  value = aws_s3_bucket.website_bucket.bucket
 }

--- a/providers.tf
+++ b/providers.tf
@@ -14,10 +14,7 @@ terraform {
     }
   }
   required_providers {
-    random = {
-      source = "hashicorp/random"
-      version = "3.5.1"
-    }
+    
     aws = {
       source = "hashicorp/aws"
       version = "5.16.2"

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -1,1 +1,2 @@
 user_uuid="db8fc491-7712-4149-b2c2-19a84f7c3cc6"
+bucket_name="ivcj9ect1ex2hk158j7uozqdfbdj9f2l"

--- a/variables.tf
+++ b/variables.tf
@@ -6,3 +6,16 @@ variable "user_uuid" {
     error_message    = "The user_uuid value is not a valid UUID."
   }
 }
+
+variable "bucket_name" {
+  description = "The name of the S3 bucket"
+  type        = string
+
+  validation {
+    condition     = (
+      length(var.bucket_name) >= 3 && length(var.bucket_name) <= 63 && 
+      can(regex("^[a-z0-9][a-z0-9-.]*[a-z0-9]$", var.bucket_name))
+    )
+    error_message = "The bucket name must be between 3 and 63 characters, start and end with a lowercase letter or number, and can contain only lowercase letters, numbers, hyphens, and dots."
+  }
+} 


### PR DESCRIPTION
- [x]  use terraform import
- [x] purposely cause configuration drift via clickops, and correct state.